### PR TITLE
Use kubectl instead of microk8s.kubectl

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,18 +20,18 @@ runs:
   using: "composite"
   steps:
     - name: Get all
-      run: sudo microk8s.kubectl get all -A
+      run: sudo kubectl get all -A
       shell: bash
 
     - name: Describe deployments
       run: |
-        sudo microk8s.kubectl describe \
+        sudo kubectl describe \
           deployments -A
       shell: bash
 
     - name: Describe replicasets
       run: |
-        sudo microk8s.kubectl describe \
+        sudo kubectl describe \
           replicasets -A
       shell: bash
 
@@ -41,7 +41,7 @@ runs:
 
     - name: Get application charm logs
       run: |
-        sudo microk8s.kubectl logs \
+        sudo kubectl logs \
           -n ${{ inputs.model }} \
           --all-containers \
           --tail 1000 \
@@ -49,7 +49,7 @@ runs:
       shell: bash
     - name: Get operator controller logs
       run: |
-        sudo microk8s.kubectl logs \
+        sudo kubectl logs \
           -n ${{ inputs.model }} \
           --tail 1000 \
           --selector operator.juju.is/name=${{ inputs.operator }}


### PR DESCRIPTION
The charm CI will sometimes use different providers than microk8s - could this be changed to use `kubectl` instead of `microk8s.kubectl`?  When using the actions-operator with microk8s, kubectl is configured by default.  

Pretty sure the `sudo` can also be dropped if changed but haven't tested