### PR TITLE
remove sudo from kubectl calls

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,23 +17,23 @@ inputs:
     description: |
       The label of the Juju operator pod to print the info for.  Defaults
       to `modeloperator`, which is the model operator.
-  
+
 runs:
   using: "composite"
   steps:
     - name: Get all
-      run: sudo kubectl get all -A
+      run: kubectl get all -A
       shell: bash
 
     - name: Describe deployments
       run: |
-        sudo kubectl describe \
+        kubectl describe \
           deployments -A
       shell: bash
 
     - name: Describe replicasets
       run: |
-        sudo kubectl describe \
+        kubectl describe \
           replicasets -A
       shell: bash
 
@@ -43,7 +43,7 @@ runs:
 
     - name: Get application charm logs
       run: |
-        sudo kubectl logs \
+        kubectl logs \
           -n ${{ inputs.model }} \
           --all-containers \
           --tail 1000 \
@@ -51,7 +51,7 @@ runs:
       shell: bash
     - name: Get operator controller logs
       run: |
-        sudo kubectl logs \
+        kubectl logs \
           -n ${{ inputs.model }} \
           --tail 1000 \
           --selector operator.juju.is/name=${{ inputs.operator }}


### PR DESCRIPTION
As first mentioned in [this commit](https://github.com/canonical/charm-logdump-action/commit/3688336a08fcd7e84a7410e42eee0664bb4ccbc5)

```
Pretty sure the `sudo` can also be dropped if changed but haven't tested
```

We used this action in some of our projects and we can confirm that indeed `sudo` can be dropped, in most cases with the way microk8s is setup it actually errors when using `kubectl` with `sudo`.