### PR TITLE
Include relations from juju status, describe statefulsets

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,11 @@ runs:
       run: kubectl get all -A
       shell: bash
 
+    - name: Describe statefulsets
+      run: |
+        kubectl describe \
+          statefulsets -A
+
     - name: Describe deployments
       run: |
         kubectl describe \
@@ -38,7 +43,7 @@ runs:
       shell: bash
 
     - name: Get juju status
-      run: juju status
+      run: juju status --relations
       shell: bash
 
     - name: Get application charm logs


### PR DESCRIPTION
Sidecar charms are all statefulsets, so it'd be useful to include a describe of those in addition to deployments.

Also, we should include relations when querying `juju status`.