### PR TITLE
add -m option to juju status

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
       shell: bash
 
     - name: Get juju status
-      run: juju status
+      run: juju status -m ${{ inputs.model }}
       shell: bash
 
     - name: Get application charm logs

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,11 @@ runs:
       run: kubectl get all -A
       shell: bash
 
+    - name: Describe statefulsets
+      run: |
+        kubectl describe \
+          statefulsets -A
+
     - name: Describe deployments
       run: |
         kubectl describe \
@@ -38,7 +43,7 @@ runs:
       shell: bash
 
     - name: Get juju status
-      run: juju status -m ${{ inputs.model }}
+      run: juju status --relations -m ${{ inputs.model }}
       shell: bash
 
     - name: Get application charm logs


### PR DESCRIPTION
In certain situation, the juju model is not automatically added to the context, to cover for those cases, we'd need to pass the `-m` flag to `juju status`