### PR TITLE
Add missing input argument

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,7 @@ runs:
       run: |
         kubectl describe \
           statefulsets -A
+      shell: bash
 
     - name: Describe deployments
       run: |


### PR DESCRIPTION
workflows are failing because of missing `shell: bash` input in one of the steps